### PR TITLE
Fix create button to toggle orange color on click

### DIFF
--- a/motorcycle-dynamics/main.py
+++ b/motorcycle-dynamics/main.py
@@ -38,7 +38,7 @@ selected_button = None
 
 # Draw the 'Create' button
 def draw_create_button(highlighted):
-    color = SOFT_YELLOW if highlighted else SOFT_YELLOW
+    color = SOFT_ORANGE if highlighted else SOFT_YELLOW
     pygame.draw.rect(screen, color, pygame.Rect(0, 20, 100, 20))
     text = font.render('CREATE', True, BLACK, None)
     screen.blit(text, (10, 22))


### PR DESCRIPTION
Modifies the 'Create' button behavior in `motorcycle-dynamics/main.py` to enhance user interaction by changing its color to orange when clicked and maintaining that state until it is clicked again.

- Changes the color of the 'Create' button to `SOFT_ORANGE` when it is highlighted, making it visually distinct when active.
- Maintains the toggle functionality of the button's highlighted state, ensuring it stays orange until clicked again, which aligns with the user's expectation for interactive elements.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/motorcycle-dynamics?shareId=21b7e8dd-8cd0-46e8-9fce-b1ce5239416a).