### PR TITLE
Enable snap function by default

### DIFF
--- a/motorcycle-dynamics/ui_buttons.py
+++ b/motorcycle-dynamics/ui_buttons.py
@@ -67,7 +67,7 @@ highlighted = {
 checkbox_states = {
     "1ft": True,   # 1' grid is visible by default
     "1in": False,  # 1" grid is not visible by default
-    "snap": False, # Snap is not enabled by default
+    "snap": True, # Snap is now enabled by default
 }
 
 selected_button_group = None


### PR DESCRIPTION
Updates the default state of the "snap" checkbox to be enabled in the `motorcycle-dynamics/ui_buttons.py` file.

- Changes the default state of the "snap" checkbox from `False` to `True` in the `checkbox_states` dictionary, ensuring that the snap function is enabled by default when the application starts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/motorcycle-dynamics?shareId=99422af4-389a-4a89-8e36-5382e72de6a5).