### PR TITLE
Fix missing arguments in draw_beams function call

### DIFF
--- a/motorcycle-dynamics/main.py
+++ b/motorcycle-dynamics/main.py
@@ -77,7 +77,7 @@ def main(screen):
 
         draw_ui(screen, nodes, beams)
         draw_nodes(screen, nodes)
-        draw_beams(screen, beams)
+        draw_beams(screen, beams, nodes, fixtures, masses)
         draw_fixtures(screen, fixtures)
         draw_masses(screen, masses)
 


### PR DESCRIPTION
Fixes the crash issue by updating the `draw_beams` function call to include the required arguments.

- Updates the `draw_beams` function call in `main.py` to include `nodes`, `fixtures`, and `masses` as arguments, addressing the crash issue due to missing arguments.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/motorcycle-dynamics?shareId=0f6f4b3b-d954-4d49-b4fe-59eaa9133f36).