### PR TITLE
Fix LinAlgError in method_of_joints.py

### DIFF
--- a/motorcycle-dynamics/method_of_joints.py
+++ b/motorcycle-dynamics/method_of_joints.py
@@ -41,8 +41,8 @@ def calculate_joint_forces(nodes, beams, fixtures, weights):
             b.append(-joint_forces[i]["Fx"])
             b.append(-joint_forces[i]["Fy"])
 
-    A = np.array(A)
-    b = np.array(b)
+    A = np.atleast_2d(np.array(A))
+    b = np.atleast_2d(np.array(b)).T
 
     beam_forces = np.linalg.solve(A, b)
 


### PR DESCRIPTION
Fixes the LinAlgError by ensuring arrays are at least two-dimensional before solving linear equations in `method_of_joints.py`.

- Ensures `A` and `b` arrays are at least two-dimensional by using `np.atleast_2d()` for `A` and reshaping `b` with `.T` to meet `numpy.linalg.solve` requirements.
- Prevents the `LinAlgError` that occurred when attempting to solve the system of linear equations with one-dimensional arrays.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/motorcycle-dynamics?shareId=4c0ab669-6d09-425e-aac1-537e3132717f).